### PR TITLE
Add new spreedly paywaydotcom gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/payway_dot_com.rb
+++ b/lib/active_merchant/billing/gateways/payway_dot_com.rb
@@ -1,0 +1,316 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class PaywayDotComGateway < Gateway
+      self.test_url = 'https://devedgilpayway.net/PaywayWS/Payment/'
+      self.live_url = 'https://edgilpayway.com/PaywayWS/Payment/'
+
+      self.supported_countries = ['US', 'CA']
+      self.default_currency = 'USD'
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+
+      self.money_format = :cents
+
+      self.homepage_url = 'http://www.payway.com'
+      self.display_name = 'Payway Gateway'
+
+      STANDARD_ERROR_CODE_MAPPING = {
+        '5012' => STANDARD_ERROR_CODE[:card_declined],
+        '5035' => STANDARD_ERROR_CODE[:invalid_number],
+        '5037' => STANDARD_ERROR_CODE[:invalid_expiry_date], # The expiration date is invalid.
+        '5045' => STANDARD_ERROR_CODE[:incorrect_zip] # The zip code or postal code is invalid.
+      }
+
+      # Payway to standard AVSResult codes.
+      AVS_MAPPING = {
+        'N1'  => 'I', #  No address given with order
+        'N2'  => 'I', #  Bill-to address did not pass
+        '““'  => 'R', #  AVS not performed (Blanks returned)
+        'IU'  => 'G', #  AVS not performed by Issuer
+        'ID'  => 'S', #  Issuer does not participate in AVS
+        'IE'  => 'E', #  Edit Error – AVS data is invalid
+        'IS'  => 'R', #  System unavailable or time-out
+        'IB'  => 'B', #  Street address match. Postal code not verified due to incompatible formats (both were sent).
+        'IC'  => 'C', #  Street address and postal code not verified due to incompatible format (both were sent).
+        'IP'  => 'P', #  Postal code match. Street address not verified due to incompatible formats (both were sent).
+        'A1'  => 'K', #  Accountholder name matches
+        'A3'  => 'V', #  Accountholder name, billing address and postal code.
+        'A4'  => 'L', #  Accountholder name and billing postal code match
+        'A7'  => 'O', #  Accountholder name and billing address match
+        'B3'  => 'H', #  Accountholder name incorrect, billing address and postal code match
+        'B4'  => 'F', #  Accountholder name incorrect, billing postal code matches
+        'B7'  => 'T', #  Accountholder name incorrect, billing address matches
+        'B8'  => 'N', #  Accountholder name, billing address and postal code are all incorrect
+        '??'  => 'R', #  A double question mark symbol “??” indicates an unrecognized response from association
+        'I1'  => 'X', #  Zip code + 4 and Address Match
+        'I2'  => 'W', #  Zip code +4 Match
+        'I3'  => 'Y', #  Zip code and Address Match
+        'I4'  => 'Z', #  Zip code Match
+        'I5'  => 'M', #  +4 and Address Match
+        'I6'  => 'W', #  +4 Match
+        'I7'  => 'A', #  Address Match
+        'I8'  => 'C', #  No Match
+      }
+
+      CREDIT_CARD = 'CreditCard'
+      ACH = 'ACH'
+
+      PAYWAY_WS_SUCCESS = '5000'
+
+      SCRUB_PATTERNS = [
+        %r(("password\\?":\\?")[^\\]+),
+        %r(("fsv\\?":\\?")\d+),
+        %r(("accountNumber\\?":\\?")\d+)
+      ].freeze
+
+      SCRUB_REPLACEMENT = '\1[FILTERED]'
+
+      def initialize(options={})
+        requires!(options, :login, :password, :company_id)
+        super
+      end
+
+      def purchase(money, payment, options={})
+        post = {}
+        add_common(post, options)
+        add_card_payment(post, payment, options)
+        if payment.is_a?(CreditCard)
+          add_card_transaction(post, money, options)
+        else
+          add_ach_transaction(post, money, options)
+        end
+        add_address(post, payment, options)
+
+        commit('sale', post)
+      end
+
+      def authorize(money, payment, options={})
+        post = {}
+        add_common(post, options)
+        add_card_payment(post, payment, options)
+        add_card_transaction(post, money, options)
+        add_address(post, payment, options)
+
+        commit('authorize', post)
+      end
+
+      def capture(money, authorization, options={})
+        post = {}
+        add_common(post, options)
+        add_card_transaction_name_and_source(post, authorization, options)
+
+        commit('capture', post)
+      end
+
+      def credit(money, payment, options={})
+        post = {}
+        add_common(post, options)
+        add_card_payment(post, payment, options)
+        if payment.is_a?(CreditCard)
+          add_card_transaction(post, money, options)
+        else
+          add_ach_transaction(post, money, options)
+        end
+        add_address(post, payment, options)
+
+        commit('credit', post)
+      end
+
+      def void(authorization, options={})
+        post = {}
+        add_common(post, options)
+        # todo: need to read transaction name using Query to determine if credit card or ach/Check
+        # then check if have creditCard or bankAccount
+        add_card_transaction_name_and_source(post, authorization, options)
+        #else
+        #  add_ach_transaction_name_and_source(post, authorization, options)
+        #end
+
+        commit('void', post)
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        SCRUB_PATTERNS.inject(transcript) do |text, pattern|
+          text.gsub(pattern, SCRUB_REPLACEMENT)
+        end
+      end
+
+      private
+
+      def add_common(post, options)
+        post[:userName] = @options[:login]
+        post[:password] = @options[:password]
+        post[:companyId] = @options[:company_id]
+      end
+
+      def add_card_transaction_name_and_source(post, identifier, options)
+        post[:cardTransaction] ||= {}
+        post[:cardTransaction][:name] = identifier
+        post[:cardTransaction][:idSource] = options[:source_id] if options[:source_id]
+      end
+
+      def add_address(post, payment, options)
+        if payment.is_a?(CreditCard)
+          post[:cardAccount] ||= {}
+          address = options[:billing_address] || options[:address] || {}
+          first_name, last_name = split_names(address[:name])
+          full_address = "#{address[:address1]} #{address[:address2]}".strip
+
+          post[:cardAccount][:firstName] = first_name      if first_name
+          post[:cardAccount][:lastName]  = last_name       if last_name
+          post[:cardAccount][:address]   = full_address    if full_address
+          post[:cardAccount][:city]      = address[:city]  if address[:city]
+          post[:cardAccount][:state]     = address[:state] if address[:state]
+          post[:cardAccount][:zip]       = address[:zip]   if address[:zip]
+          post[:cardAccount][:phone]     = address[:phone] if address[:phone]
+        end
+      end
+
+      def add_card_transaction(post, money, options)
+        post[:cardTransaction] ||= {}
+        post[:cardTransaction][:amount] = amount(money)
+        # get or set eci Type from options or set default to "1" for MOTO
+        eci_type = options[:eci_type].nil? ? "1" : options[:eci_type]
+        post[:cardTransaction][:eciType] = eci_type
+        # need source, required or will return source not found
+        post[:cardTransaction][:idSource] = options[:source_id] if options[:source_id]
+        # optional processorSoftDescriptor
+        post[:cardTransaction][:processorSoftDescriptor] = options[:processor_soft_descriptor] if options[:processor_soft_descriptor]
+        # optional tax amount
+        post[:cardTransaction][:tax] = options[:tax] if options[:tax]
+      end
+
+      def add_ach_transaction(post, money, options)
+        post[:directDebitTransaction] ||= {}
+        post[:directDebitTransaction][:amount] = amount(money)
+        # need source, required or will return source not found
+        post[:directDebitTransaction][:idSource] = options[:source_id] if options[:source_id]
+        # optional tax amount
+        post[:directDebitTransaction][:tax] = options[:tax] if options[:tax]
+      end
+
+      def add_card_payment(post, payment, options)
+        # check payment object: credit_card, etc.
+        if payment.is_a?(String)
+          # for future use, would also need payment type if not credit card
+          post[:accountInputMode] = "paywayAccountToken"
+          post[:paywayAccountToken] = payment
+        elsif payment.is_a?(CreditCard)
+          post[:accountInputMode] = "primaryAccountNumber"
+
+          post[:cardAccount] ||= {}
+          post[:cardAccount][:accountNumber] = payment.number
+          post[:cardAccount][:fsv]           = payment.verification_value
+          post[:cardAccount][:expirationDate]    = expdate(payment)
+          # optional data
+          post[:cardAccount][:email]     = options[:email]
+        elsif payment.is_a?(Check)
+          post[:accountInputMode] = "primaryAccountNumber"
+
+          post[:bankAccount] ||= {}
+          post[:bankAccount][:accountNumber] = payment.account_number
+          post[:bankAccount][:routingNumber] = payment.routing_number
+          post[:bankAccount][:firstName] = payment.first_name
+          post[:bankAccount][:lastName] = payment.last_name
+          post[:bankAccount][:accountType] = payment.account_type
+          # optional data
+          post[:bankAccount][:email]     = options[:email]
+        end
+      end
+
+      def expdate(credit_card)
+        year  = format(credit_card.year, :four_digits)
+        month = format(credit_card.month, :two_digits)
+
+        # return MMYYYY
+        month + year
+      end
+
+      def parse(body)
+        body.blank? ? {} : JSON.parse(body)
+      end
+
+      def commit(action, parameters)
+        # set request name
+        parameters[:request] = action
+
+        # check and set url for ACH, add check for Query or Payment later
+        creditCard_or_ACH = parameters[:cardTransaction].nil? ? ACH : CREDIT_CARD
+        url = (test? ? test_url + creditCard_or_ACH : live_url + creditCard_or_ACH)
+        payload = parameters.to_json unless parameters.nil?
+
+        response =
+          begin
+            parse(ssl_request(:post, url, payload, headers ))
+            rescue ResponseError => e
+            return Response.new(false, 'Invalid Login') if e.response.code == '401'
+
+            parse(e.response.body)
+          end
+
+        success = success_from(response)
+        avs_result_code = response['cardTransaction'].nil? || response['cardTransaction']['addressVerificationResults'].nil? ? "" : response['cardTransaction']['addressVerificationResults']
+        avs_result = AVSResult.new(code: AVS_MAPPING[avs_result_code])
+        cvv_result = CVVResult.new(response['cardTransaction']['fraudSecurityResults']) if response['cardTransaction'] && response['cardTransaction']['fraudSecurityResults']
+
+        Response.new(
+          success,
+          message_from(success, response),
+          response,
+          test: test?,
+          error_code: error_code_from(response),
+          authorization: authorization_from(response),
+          avs_result: avs_result,
+          cvv_result: cvv_result
+        )
+      end
+
+      def success_from(response)
+        response['paywayCode'] == PAYWAY_WS_SUCCESS
+      end
+
+      def error_code_from(response)
+        if success_from(response)
+          ''
+        else
+          error = !STANDARD_ERROR_CODE_MAPPING[response['paywayCode']].nil? ?
+          STANDARD_ERROR_CODE_MAPPING[response['paywayCode']] :
+          STANDARD_ERROR_CODE[:processing_error]
+        end
+      end
+
+      def message_from(success, response)
+        if !response['paywayCode'].nil?
+          if success
+            return response['paywayCode'] + "-" + "success"
+          else
+            return response['paywayCode'] + "-" + response['paywayMessage']
+          end
+        end
+        ""
+      end
+
+      def authorization_from(response)
+        if success_from(response)
+          if !response['cardTransaction'].nil?
+            return response['cardTransaction']['name'] if response['cardTransaction']['name']
+          elsif !response['directDebitTransaction'].nil?
+            return response['directDebitTransaction']['name'] if response['directDebitTransaction']['name']
+          end
+        end
+        ""
+      end
+
+      # Builds the headers for the request
+      def headers
+        {
+          'Accept'        => 'application/json',
+          'Content-type'  => 'application/json'
+        }
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -799,6 +799,12 @@ payway:
   password:
   pem:
 
+# Working credentials, no need to replace
+payway_dot_com:
+  login:      "sprerestwsdev"
+  password:   "sprerestwsdev1!"
+  company_id: "3"
+
 pin:
   api_key: "I_mo9BUUUXIwXF-avcs3LA"
 

--- a/test/remote/gateways/remote_payway_dot_com_test.rb
+++ b/test/remote/gateways/remote_payway_dot_com_test.rb
@@ -1,0 +1,162 @@
+require 'test_helper'
+
+class RemotePaywayDotComTest < Test::Unit::TestCase
+  def setup
+    @gateway = PaywayDotComGateway.new(fixtures(:payway_dot_com))
+
+    @amount = 100
+    @credit_card = credit_card('4000100011112224', verification_value: '737')
+    @declined_card = credit_card('4000300011112220')
+    @invalid_luhn_card = credit_card('4000300011112221')
+    @options = {
+      billing_address: address,
+      description: 'Store Purchase',
+      # source_id must be provided, contact payway support for valid source_id(s)
+      source_id: '67'
+    }
+    @check = check(number: rand(0..100000), routing_number: '091000019')
+    @check_invalid_aba = check({
+      bank_name: 'TEST BANK',
+      account_number: '000123456789',
+      routing_number: '110000000'
+    })
+    @check_aba_too_short = check(routing_number: '54321')
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    #assert_equal 'REPLACE WITH SUCCESS MESSAGE', response.message
+    assert_equal '5000', response.message[0,4]
+  end
+
+  def test_successful_purchase_with_more_options
+    options = {
+      order_id: '1',
+      ip: "127.0.0.1",
+      email: "joe@example.com",
+      # source_id must be provided, contact payway support for valid source_id(s)
+      source_id: '67',
+      # change eci type, set to 5 for eCommerce 
+      eci_type: '5',
+      # set tax to 7 cents
+      tax:      '7',
+      # soft descriptor
+      soft_descriptor: "Dan's Guitar Store"
+    }
+
+    # test email and eci_type and tax
+    response = @gateway.purchase(101, @credit_card, options)
+    assert_success response
+    assert_equal '5000', response.message[0,4]
+  end
+
+  def test_failed_purchase
+    #response = @gateway.purchase(@amount, @invalid_luhn_card, @options.merge( { test_result_code: '5012' }))
+    response = @gateway.purchase(102, @invalid_luhn_card, @options)
+    assert_failure response
+    assert_equal PaywayDotComGateway::STANDARD_ERROR_CODE_MAPPING['5035'], response.error_code
+    assert_equal '5035', response.message[0,4]
+  end
+
+  def test_successful_authorize
+    auth_only = @gateway.authorize(103, @credit_card, @options)
+    assert_success auth_only
+    assert_equal '5000', auth_only.message[0,4]
+  end
+
+  def test_successful_authorize_and_capture
+    auth = @gateway.authorize(104, @credit_card, @options)
+    assert_success auth
+    # need options to pass in source id 
+    assert capture = @gateway.capture(@amount, auth.authorization, @options)
+    assert_success capture
+    assert_equal '5000', capture.message[0,4]
+  end
+
+  def test_failed_authorize
+    response = @gateway.authorize(105, @invalid_luhn_card, @options)
+    assert_failure response
+    assert_equal '5035', response.message[0,4]
+  end
+
+  def test_failed_capture
+    response = @gateway.capture(106, '')
+    assert_failure response
+    assert_equal '5025', response.message[0,4]
+  end
+
+  def test_successful_credit
+    credit = @gateway.credit(107, @credit_card, @options)
+    assert_success credit
+    assert_equal '5000', credit.message[0,4]
+  end
+
+  # void authorization only
+  def test_successful_void
+    auth = @gateway.authorize(108, @credit_card, @options)
+    assert_success auth
+
+    # need options for passing required source id
+    assert void = @gateway.void(auth.authorization, @options)
+    assert_success void
+    assert_equal '5000', void.message[0,4]
+  end
+
+  def test_failed_void
+    response = @gateway.void('')
+    assert_failure response
+    assert_equal '5025', response.message[0,4]
+  end
+
+  # void of purchase (sale)
+  def test_successful_void_of_sale
+    sale = @gateway.purchase(109, @credit_card, @options)
+    assert_success sale
+
+    # need options for passing required source id
+    assert void = @gateway.void(sale.authorization, @options)
+    assert_success void
+    assert_equal '5000', void.message[0,4]
+  end
+
+  # void of credit
+  def test_successful_void_of_credit
+    credit = @gateway.credit(110, @credit_card, @options)
+    assert_success credit
+
+    # need options for passing required source id
+    assert void = @gateway.void(credit.authorization, @options)
+    assert_success void
+    assert_equal '5000', void.message[0,4]
+  end
+
+  def test_invalid_login
+    gateway = PaywayDotComGateway.new(login: '', password: '', company_id: '')
+
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_match %r{5001}, response.message[0,4]
+  end
+
+  def test_dump_transcript
+    # This test will run a purchase transaction on your gateway
+    # and dump a transcript of the HTTP conversation so that
+    # you can use that transcript as a reference while
+    # implementing your scrubbing logic.  You can delete
+    # this helper after completing your scrub implementation.
+    ##dump_transcript_and_fail(@gateway, @amount, @credit_card, @options)
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:password], transcript)
+  end
+
+end
+

--- a/test/remote/gateways/remote_payway_dot_com_test.rb
+++ b/test/remote/gateways/remote_payway_dot_com_test.rb
@@ -14,19 +14,11 @@ class RemotePaywayDotComTest < Test::Unit::TestCase
       # source_id must be provided, contact payway support for valid source_id(s)
       source_id: '67'
     }
-    @check = check(number: rand(0..100000), routing_number: '091000019')
-    @check_invalid_aba = check({
-      bank_name: 'TEST BANK',
-      account_number: '000123456789',
-      routing_number: '110000000'
-    })
-    @check_aba_too_short = check(routing_number: '54321')
   end
 
   def test_successful_purchase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
-    #assert_equal 'REPLACE WITH SUCCESS MESSAGE', response.message
     assert_equal '5000', response.message[0,4]
   end
 
@@ -92,9 +84,15 @@ class RemotePaywayDotComTest < Test::Unit::TestCase
     assert_equal '5000', credit.message[0,4]
   end
 
+  def test_failed_credit
+    response = @gateway.credit(108, @invalid_luhn_card, @options)
+    assert_failure response
+    assert_equal '5035', response.message[0,4]
+  end
+
   # void authorization only
   def test_successful_void
-    auth = @gateway.authorize(108, @credit_card, @options)
+    auth = @gateway.authorize(109, @credit_card, @options)
     assert_success auth
 
     # need options for passing required source id
@@ -111,7 +109,7 @@ class RemotePaywayDotComTest < Test::Unit::TestCase
 
   # void of purchase (sale)
   def test_successful_void_of_sale
-    sale = @gateway.purchase(109, @credit_card, @options)
+    sale = @gateway.purchase(110, @credit_card, @options)
     assert_success sale
 
     # need options for passing required source id
@@ -122,7 +120,7 @@ class RemotePaywayDotComTest < Test::Unit::TestCase
 
   # void of credit
   def test_successful_void_of_credit
-    credit = @gateway.credit(110, @credit_card, @options)
+    credit = @gateway.credit(111, @credit_card, @options)
     assert_success credit
 
     # need options for passing required source id
@@ -137,15 +135,6 @@ class RemotePaywayDotComTest < Test::Unit::TestCase
     response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_match %r{5001}, response.message[0,4]
-  end
-
-  def test_dump_transcript
-    # This test will run a purchase transaction on your gateway
-    # and dump a transcript of the HTTP conversation so that
-    # you can use that transcript as a reference while
-    # implementing your scrubbing logic.  You can delete
-    # this helper after completing your scrub implementation.
-    ##dump_transcript_and_fail(@gateway, @amount, @credit_card, @options)
   end
 
   def test_transcript_scrubbing

--- a/test/unit/gateways/payway_dot_com_test.rb
+++ b/test/unit/gateways/payway_dot_com_test.rb
@@ -1,0 +1,1346 @@
+require 'test_helper'
+
+class PaywayDotComTest < Test::Unit::TestCase
+  def setup
+    @gateway = PaywayDotComGateway.new(
+        login: 'sprerestwsdev',
+        password: 'sprerestwsdev1!',
+        company_id: '3')
+    @gateway2 = PaywayDotComGateway.new(login: '', password: '', company_id: '')
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase',
+      source_id: '67'
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_request).returns(successful_purchase_response)
+  
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal '5000', response.message[0,4]
+    assert_equal '0987654321', response.params['cardTransaction']['authorizationCode']
+    assert_equal '', response.error_code
+    assert response.test?
+    assert_equal 'Z', response.avs_result['code']
+    assert_equal 'M', response.cvv_result['code']    
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:ssl_request).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal '5035', response.message[0,4]
+    assert_equal Gateway::STANDARD_ERROR_CODE[:invalid_number], response.error_code
+  end
+
+  def test_successful_authorize
+    @gateway.expects(:ssl_request).returns(successful_authorize_response)
+  
+    auth_only = @gateway.authorize(103, @credit_card, @options)
+    assert_success auth_only
+    assert_equal '5000', auth_only.message[0,4]
+  end
+
+  def test_successful_authorize_and_capture
+    @gateway.expects(:ssl_request).returns(successful_authorize_and_capture_response)
+  
+    auth = @gateway.authorize(104, @credit_card, @options)
+    assert_success auth
+
+    # need options to pass in source id 
+    @gateway.expects(:ssl_request).returns(successful_capture_response)
+
+    assert capture = @gateway.capture(@amount, auth.authorization, @options)
+    assert_success capture
+    assert_equal '5000', capture.message[0,4]
+  end
+
+  def test_failed_authorize
+    @gateway.expects(:ssl_request).returns(failed_authorize_response)
+
+    response = @gateway.authorize(105, @invalid_luhn_card, @options)
+    assert_failure response
+    assert_equal '5035', response.message[0,4]
+  end
+
+  def test_failed_capture
+    @gateway.expects(:ssl_request).returns(failed_capture_response)
+
+    response = @gateway.capture(106, '')
+    assert_failure response
+    assert_equal '5025', response.message[0,4]
+  end
+
+  def test_successful_credit
+    @gateway.expects(:ssl_request).returns(successful_credit_response)
+  
+    credit = @gateway.credit(107, @credit_card, @options)
+    assert_success credit
+    assert_equal '5000', credit.message[0,4]
+  end
+
+  # void authorization only
+  def test_successful_void
+    @gateway.expects(:ssl_request).returns(successful_auth_for_void_response)
+  
+    auth = @gateway.authorize(108, @credit_card, @options)
+    assert_success auth
+
+    @gateway.expects(:ssl_request).returns(successful_void_auth_response)
+  
+    # need options for passing required source id
+    assert void = @gateway.void(auth.authorization, @options)
+    assert_success void
+    assert_equal '5000', void.message[0,4]
+  end
+
+  def test_failed_void
+    @gateway.expects(:ssl_request).returns(failed_void_response)
+
+    response = @gateway.void('')
+    assert_failure response
+    assert_equal '5025', response.message[0,4]
+  end
+
+  # void of purchase (sale)
+  def test_successful_void_of_sale
+    @gateway.expects(:ssl_request).returns(successful_sale_for_void_response)
+  
+    sale = @gateway.purchase(109, @credit_card, @options)
+    assert_success sale
+
+    @gateway.expects(:ssl_request).returns(successful_void_sale_response)
+  
+    # need options for passing required source id
+    assert void = @gateway.void(sale.authorization, @options)
+    assert_success void
+    assert_equal '5000', void.message[0,4]
+  end
+
+  # void of credit
+  def test_successful_void_of_credit
+    @gateway.expects(:ssl_request).returns(successful_credit_for_void_response)
+  
+    credit = @gateway.credit(110, @credit_card, @options)
+    assert_success credit
+
+    @gateway.expects(:ssl_request).returns(successful_credit_void_response)
+
+    # need options for passing required source id
+    assert void = @gateway.void(credit.authorization, @options)
+    assert_success void
+    assert_equal '5000', void.message[0,4]
+  end
+
+  def test_invalid_login
+    @gateway2.expects(:ssl_request).returns(failed_invalid_login_response)
+
+    assert response = @gateway2.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_match %r{5001}, response.message[0,4]
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+#<- "POST /PaywayWS/Payment/CreditCard HTTP/1.1\r\nContent-Type: application/json\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: devedgilpayway.net\r\nContent-Length: 436\r\n\r\n"
+
+  def pre_scrubbed
+    %q(
+opening connection to devedgilpayway.net:443...
+opened
+starting SSL for devedgilpayway.net:443...
+SSL established, protocol: TLSv1.2, cipher: AES256-GCM-SHA384
+<- "{\"userName\":\"sprerestwsdev\",\"password\":\"sprerestwsdev1!\",\"companyId\":\"3\",\"accountInputMode\":\"primaryAccountNumber\",\"cardAccount\":{\"accountNumber\":\"4000100011112224\",\"fsv\":\"737\",\"expirationDate\":\"092022\",\"email\":null,\"firstName\":\"Jim\",\"lastName\":\"Smith\",\"address\":\"456 My Street Apt 1\",\"city\":\"Ottawa\",\"state\":\"ON\",\"zip\":\"K1C2N6\",\"phone\":\"(555)555-5555\"},\"cardTransaction\":{\"amount\":\"100\",\"eciType\":\"1\",\"idSource\":\"67\"},\"request\":\"sale\"}"
+-> "HTTP/1.1 200 \r\n"
+-> "Access-Control-Allow-Origin: *\r\n"
+-> "Access-Control-Expose-Headers: Access-Control-Allow-Origin,Access-Control-Allow-Credentials\r\n"
+-> "Content-Encoding: application/json\r\n"
+-> "Content-Type: application/json\r\n"
+-> "Content-Length: 2051\r\n"
+)
+  end
+
+#<- "POST /PaywayWS/Payment/CreditCard HTTP/1.1\r\nContent-Type: application/json\r\nAccept: application/json\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nHost: devedgilpayway.net\r\nContent-Length: 436\r\n\r\n"
+
+  def post_scrubbed
+    %q(
+opening connection to devedgilpayway.net:443...
+opened
+starting SSL for devedgilpayway.net:443...
+SSL established, protocol: TLSv1.2, cipher: AES256-GCM-SHA384
+<- "{\"userName\":\"sprerestwsdev\",\"password\":\"[FILTERED]\",\"companyId\":\"3\",\"accountInputMode\":\"primaryAccountNumber\",\"cardAccount\":{\"accountNumber\":\"[FILTERED]\",\"fsv\":\"[FILTERED]\",\"expirationDate\":\"092022\",\"email\":null,\"firstName\":\"Jim\",\"lastName\":\"Smith\",\"address\":\"456 My Street Apt 1\",\"city\":\"Ottawa\",\"state\":\"ON\",\"zip\":\"K1C2N6\",\"phone\":\"(555)555-5555\"},\"cardTransaction\":{\"amount\":\"100\",\"eciType\":\"1\",\"idSource\":\"67\"},\"request\":\"sale\"}"
+-> "HTTP/1.1 200 \r\n"
+-> "Access-Control-Allow-Origin: *\r\n"
+-> "Access-Control-Expose-Headers: Access-Control-Allow-Origin,Access-Control-Allow-Credentials\r\n"
+-> "Content-Encoding: application/json\r\n"
+-> "Content-Type: application/json\r\n"
+-> "Content-Length: 2051\r\n"
+)
+  end
+
+  def successful_purchase_response
+  '{
+      "cardAccount": {
+          "accountNotes1": "",
+          "accountNotes2": "",
+          "accountNotes3": "",
+          "accountNumber": "400010******2224",
+          "account_number_masked": "400010******2224",
+          "address": "456 My Street Apt 1",
+          "auLastUpdate": "1999-01-01 00:00:00-05",
+          "auUpdateType": 0,
+          "cardType": 1,
+          "city": "Ottawa",
+          "commercialCardType": 0,
+          "divisionId": 7,
+          "email": "",
+          "expirationDate": "0922",
+          "firstFour": "4000",
+          "firstName": "Jim",
+          "fsv": "",
+          "inputMode": 1,
+          "lastFour": "2224",
+          "lastName": "Smith",
+          "lastUsed": "1999-01-01 00:00:00-05",
+          "middleName": "",
+          "onlinePaymentCryptogram": "",
+          "p2peInput": "",
+          "paywayToken": 10163736,
+          "phone": "5555555555",
+          "state": "ON",
+          "status": 2,
+          "zip": "K1C2N6"
+      },
+      "cardTransaction": {
+          "addressVerificationResults": "I4",
+          "amount": 100,
+          "authorizationCode": "0987654321",
+          "authorizedTime": "2021-02-08 00:00:00-05",
+          "capturedTime": "2021-02-08 18:17:49",
+          "cbMode": 2,
+          "eciType": 1,
+          "fraudSecurityResults": "M",
+          "fsvIndicator": "",
+          "name": "6720210208181749349115",
+          "pfpstatus": 3601,
+          "pfpstatusString": "PFP Not Enabled",
+          "processorErrorMessage": "",
+          "processorOrderId": "",
+          "processorRecurringAdvice": "",
+          "processorResponseDate": "",
+          "processorResultCode": "",
+          "processorSequenceNumber": 0,
+          "processorSoftDescriptor": "",
+          "referenceNumber": "123456",
+          "resultCode": 0,
+          "sessionToken_string": "0",
+          "settledTime": "1999-01-01 00:00",
+          "sourceId": 67,
+          "status": 4,
+          "tax": 0,
+          "testResultAVS": "",
+          "testResultFSV": "",
+          "transactionNotes1": "",
+          "transactionNotes2": "",
+          "transactionNotes3": ""
+      },
+      "paywayCode": "5000",
+      "paywayMessage": ""
+  }'
+  end
+  
+    %(
+      Easy to capture by setting the DEBUG_ACTIVE_MERCHANT environment variable
+      to "true" when running remote tests:
+
+      $ DEBUG_ACTIVE_MERCHANT=true ruby -Itest \
+        test/remote/gateways/remote_payway_dot_com_test.rb \
+        -n test_successful_purchase
+    )
+
+
+  def failed_purchase_response
+  '{
+    "cardAccount": {
+        "accountNotes1": "",
+        "accountNotes2": "",
+        "accountNotes3": "",
+        "accountNumber": "400030******2221",
+        "account_number_masked": "400030******2221",
+        "address": "456 My Street Apt 1",
+        "auLastUpdate": "1999-01-01 00:00",
+        "auUpdateType": 0,
+        "cardType": 1,
+        "city": "Ottawa",
+        "commercialCardType": 0,
+        "divisionId": 7,
+        "email": "",
+        "expirationDate": "0922",
+        "firstFour": "4000",
+        "firstName": "Jim",
+        "fsv": "123",
+        "inputMode": 1,
+        "lastFour": "2221",
+        "lastName": "Smith",
+        "lastUsed": "1999-01-01 00:00",
+        "middleName": "",
+        "onlinePaymentCryptogram": "",
+        "p2peInput": "",
+        "paywayToken": 0,
+        "phone": "5555555555",
+        "state": "ON",
+        "status": 2,
+        "zip": "K1C2N6"
+    },
+    "cardTransaction": {
+        "addressVerificationResults": "",
+        "amount": 0,
+        "authorizationCode": "",
+        "authorizedTime": "1999-01-01",
+        "capturedTime": "1999-01-01",
+        "cbMode": 0,
+        "eciType": 0,
+        "fraudSecurityResults": "",
+        "fsvIndicator": "",
+        "name": "",
+        "pfpstatus": 3601,
+        "pfpstatusString": "PFP Not Enabled",
+        "processorErrorMessage": "",
+        "processorOrderId": "",
+        "processorRecurringAdvice": "",
+        "processorResponseDate": "",
+        "processorResultCode": "",
+        "processorSequenceNumber": 0,
+        "processorSoftDescriptor": "",
+        "referenceNumber": "",
+        "resultCode": 1,
+        "sessionToken_string": "0",
+        "settledTime": "1999-01-01 00:00",
+        "sourceId": 0,
+        "status": 0,
+        "tax": 0,
+        "testResultAVS": "",
+        "testResultFSV": "",
+        "transactionNotes1": "",
+        "transactionNotes2": "",
+        "transactionNotes3": ""
+    },
+    "paywayCode": "5035",
+    "paywayMessage": "Invalid account number: 4000300011112221"
+  }'
+  end
+
+  def successful_authorize_response
+  '{
+      "cardAccount": {
+          "accountNotes1": "",
+          "accountNotes2": "",
+          "accountNotes3": "",
+          "accountNumber": "400010******2224",
+          "account_number_masked": "400010******2224",
+          "address": "456 My Street Apt 1",
+          "auLastUpdate": "1999-01-01 00:00",
+          "auUpdateType": 0,
+          "cardType": 1,
+          "city": "Ottawa",
+          "commercialCardType": 0,
+          "divisionId": 7,
+          "email": "",
+          "expirationDate": "0922",
+          "firstFour": "4000",
+          "firstName": "Jim",
+          "fsv": "737",
+          "inputMode": 1,
+          "lastFour": "2224",
+          "lastName": "Smith",
+          "lastUsed": "1999-01-01 00:00",
+          "middleName": "",
+          "onlinePaymentCryptogram": "",
+          "p2peInput": "",
+          "paywayToken": 10163736,
+          "phone": "5555555555",
+          "state": "ON",
+          "status": 0,
+          "zip": "K1C2N6"
+      },
+      "cardTransaction": {
+          "addressVerificationResults": "",
+          "amount": 103,
+          "authorizationCode": "0987654321",
+          "authorizedTime": "2021-02-09",
+          "capturedTime": "1999-01-01 00:00:00-05",
+          "cbMode": 2,
+          "eciType": 1,
+          "fraudSecurityResults": "",
+          "fsvIndicator": "",
+          "name": "6720210209084239789167",
+          "pfpstatus": 3601,
+          "pfpstatusString": "PFP Not Enabled",
+          "processorErrorMessage": "",
+          "processorOrderId": "",
+          "processorRecurringAdvice": "",
+          "processorResponseDate": "",
+          "processorResultCode": "",
+          "processorSequenceNumber": 0,
+          "processorSoftDescriptor": "",
+          "referenceNumber": "123456",
+          "resultCode": 0,
+          "sessionToken_string": "0",
+          "settledTime": "1999-01-01 00:00",
+          "sourceId": 67,
+          "status": 3,
+          "tax": 0,
+          "testResultAVS": "",
+          "testResultFSV": "",
+          "transactionNotes1": "",
+          "transactionNotes2": "",
+          "transactionNotes3": ""
+      },
+      "paywayCode": "5000",
+      "paywayMessage": ""
+  }'
+  end
+
+  def successful_authorize_and_capture_response
+	'{
+	    "cardAccount": {
+		"accountNotes1": "",
+		"accountNotes2": "",
+		"accountNotes3": "",
+		"accountNumber": "400010******2224",
+		"account_number_masked": "400010******2224",
+		"address": "456 My Street Apt 1",
+		"auLastUpdate": "1999-01-01 00:00",
+		"auUpdateType": 0,
+		"cardType": 1,
+		"city": "Ottawa",
+		"commercialCardType": 0,
+		"divisionId": 7,
+		"email": "",
+		"expirationDate": "0922",
+		"firstFour": "4000",
+		"firstName": "Jim",
+		"fsv": "737",
+		"inputMode": 1,
+		"lastFour": "2224",
+		"lastName": "Smith",
+		"lastUsed": "1999-01-01 00:00",
+		"middleName": "",
+		"onlinePaymentCryptogram": "",
+		"p2peInput": "",
+		"paywayToken": 10163736,
+		"phone": "5555555555",
+		"state": "ON",
+		"status": 0,
+		"zip": "K1C2N6"
+	    },
+	    "cardTransaction": {
+		"addressVerificationResults": "",
+		"amount": 104,
+		"authorizationCode": "0987654321",
+		"authorizedTime": "2021-02-09",
+		"capturedTime": "1999-01-01 00:00:00-05",
+		"cbMode": 2,
+		"eciType": 1,
+		"fraudSecurityResults": "",
+		"fsvIndicator": "",
+		"name": "6720210209085526437200",
+		"pfpstatus": 3601,
+		"pfpstatusString": "PFP Not Enabled",
+		"processorErrorMessage": "",
+		"processorOrderId": "",
+		"processorRecurringAdvice": "",
+		"processorResponseDate": "",
+		"processorResultCode": "",
+		"processorSequenceNumber": 0,
+		"processorSoftDescriptor": "",
+		"referenceNumber": "123456",
+		"resultCode": 0,
+		"sessionToken_string": "0",
+		"settledTime": "1999-01-01 00:00",
+		"sourceId": 67,
+		"status": 3,
+		"tax": 0,
+		"testResultAVS": "",
+		"testResultFSV": "",
+		"transactionNotes1": "",
+		"transactionNotes2": "",
+		"transactionNotes3": ""
+	    },
+	    "paywayCode": "5000",
+	    "paywayMessage": ""
+	}'
+  end 
+  
+  def successful_capture_response
+  '{
+    "cardAccount": {
+        "accountNotes1": "",
+        "accountNotes2": "",
+        "accountNotes3": "",
+        "accountNumber": "400010******2224",
+        "account_number_masked": "400010******2224",
+        "address": "456 My Street Apt 1",
+        "auLastUpdate": "1999-01-01 00:00:00-05",
+        "auUpdateType": 0,
+        "cardType": 1,
+        "city": "Ottawa",
+        "commercialCardType": 0,
+        "divisionId": 7,
+        "email": "",
+        "expirationDate": "0922",
+        "firstFour": "4000",
+        "firstName": "Jim",
+        "fsv": "",
+        "inputMode": 1,
+        "lastFour": "2224",
+        "lastName": "Smith",
+        "lastUsed": "1999-01-01 00:00:00-05",
+        "middleName": "",
+        "onlinePaymentCryptogram": "",
+        "p2peInput": "",
+        "paywayToken": 10163736,
+        "phone": "5555555555",
+        "state": "ON",
+        "status": 2,
+        "zip": "K1C2N6"
+    },
+    "cardTransaction": {
+        "addressVerificationResults": "",
+        "amount": 104,
+        "authorizationCode": "0987654321",
+        "authorizedTime": "2021-02-09 00:00:00-05",
+        "capturedTime": "2021-02-09 08:55:26",
+        "cbMode": 2,
+        "eciType": 1,
+        "fraudSecurityResults": "",
+        "fsvIndicator": "",
+        "name": "6720210209085526437200",
+        "pfpstatus": 3601,
+        "pfpstatusString": "PFP Not Enabled",
+        "processorErrorMessage": "",
+        "processorOrderId": "",
+        "processorRecurringAdvice": "",
+        "processorResponseDate": "",
+        "processorResultCode": "",
+        "processorSequenceNumber": 0,
+        "processorSoftDescriptor": "",
+        "referenceNumber": "123456",
+        "resultCode": 0,
+        "sessionToken_string": "0",
+        "settledTime": "1999-01-01 00:00",
+        "sourceId": 67,
+        "status": 4,
+        "tax": 0,
+        "testResultAVS": "",
+        "testResultFSV": "",
+        "transactionNotes1": "",
+        "transactionNotes2": "",
+        "transactionNotes3": ""
+    },
+    "paywayCode": "5000",
+    "paywayMessage": ""
+  }'
+  end
+
+  def failed_authorize_response
+  '{
+    "cardAccount": {
+        "accountNotes1": "",
+        "accountNotes2": "",
+        "accountNotes3": "",
+        "accountNumber": "400030******2221",
+        "account_number_masked": "400030******2221",
+        "address": "456 My Street Apt 1",
+        "auLastUpdate": "1999-01-01 00:00",
+        "auUpdateType": 0,
+        "cardType": 1,
+        "city": "Ottawa",
+        "commercialCardType": 0,
+        "divisionId": 7,
+        "email": "",
+        "expirationDate": "0922",
+        "firstFour": "4000",
+        "firstName": "Jim",
+        "fsv": "123",
+        "inputMode": 1,
+        "lastFour": "2221",
+        "lastName": "Smith",
+        "lastUsed": "1999-01-01 00:00",
+        "middleName": "",
+        "onlinePaymentCryptogram": "",
+        "p2peInput": "",
+        "paywayToken": 0,
+        "phone": "5555555555",
+        "state": "ON",
+        "status": 2,
+        "zip": "K1C2N6"
+    },
+    "cardTransaction": {
+        "addressVerificationResults": "",
+        "amount": 0,
+        "authorizationCode": "",
+        "authorizedTime": "1999-01-01",
+        "capturedTime": "1999-01-01",
+        "cbMode": 0,
+        "eciType": 0,
+        "fraudSecurityResults": "",
+        "fsvIndicator": "",
+        "name": "",
+        "pfpstatus": 3601,
+        "pfpstatusString": "PFP Not Enabled",
+        "processorErrorMessage": "",
+        "processorOrderId": "",
+        "processorRecurringAdvice": "",
+        "processorResponseDate": "",
+        "processorResultCode": "",
+        "processorSequenceNumber": 0,
+        "processorSoftDescriptor": "",
+        "referenceNumber": "",
+        "resultCode": 1,
+        "sessionToken_string": "0",
+        "settledTime": "1999-01-01 00:00",
+        "sourceId": 0,
+        "status": 0,
+        "tax": 0,
+        "testResultAVS": "",
+        "testResultFSV": "",
+        "transactionNotes1": "",
+        "transactionNotes2": "",
+        "transactionNotes3": ""
+    },
+    "paywayCode": "5035",
+    "paywayMessage": "Invalid account number: 4000300011112221"
+  }'
+  end
+  
+  def failed_capture_response
+    '{
+    "cardAccount": {
+        "accountNotes1": "",
+        "accountNotes2": "",
+        "accountNotes3": "",
+        "accountNumber": "",
+        "account_number_masked": "",
+        "address": "",
+        "auLastUpdate": "1999-01-01 00:00",
+        "auUpdateType": 0,
+        "cardType": 8,
+        "city": "",
+        "commercialCardType": 0,
+        "divisionId": 0,
+        "email": "",
+        "expirationDate": "",
+        "firstFour": "",
+        "firstName": "",
+        "fsv": "",
+        "inputMode": 1,
+        "lastFour": "",
+        "lastName": "",
+        "lastUsed": "1999-01-01 00:00",
+        "middleName": "",
+        "onlinePaymentCryptogram": "",
+        "p2peInput": "",
+        "paywayToken": 0,
+        "phone": "",
+        "state": "",
+        "status": 0,
+        "zip": ""
+    },
+    "cardTransaction": {
+        "addressVerificationResults": "",
+        "amount": 0,
+        "authorizationCode": "",
+        "authorizedTime": "1999-01-01",
+        "capturedTime": "1999-01-01",
+        "cbMode": 0,
+        "eciType": 0,
+        "fraudSecurityResults": "",
+        "fsvIndicator": "",
+        "name": "",
+        "pfpstatus": 3601,
+        "pfpstatusString": "PFP Not Enabled",
+        "processorErrorMessage": "",
+        "processorOrderId": "",
+        "processorRecurringAdvice": "",
+        "processorResponseDate": "",
+        "processorResultCode": "",
+        "processorSequenceNumber": 0,
+        "processorSoftDescriptor": "",
+        "referenceNumber": "",
+        "resultCode": 1,
+        "sessionToken_string": "0",
+        "settledTime": "1999-01-01 00:00",
+        "sourceId": 0,
+        "status": 0,
+        "tax": 0,
+        "testResultAVS": "",
+        "testResultFSV": "",
+        "transactionNotes1": "",
+        "transactionNotes2": "",
+        "transactionNotes3": ""
+    },
+    "paywayCode": "5025",
+    "paywayMessage": "failed to read transaction with source 0 and name "
+  }'
+  end
+
+  def successful_credit_response
+    '{
+    "cardAccount": {
+        "accountNotes1": "",
+        "accountNotes2": "",
+        "accountNotes3": "",
+        "accountNumber": "400010******2224",
+        "account_number_masked": "400010******2224",
+        "address": "456 My Street Apt 1",
+        "auLastUpdate": "1999-01-01 00:00",
+        "auUpdateType": 0,
+        "cardType": 1,
+        "city": "Ottawa",
+        "commercialCardType": 0,
+        "divisionId": 7,
+        "email": "",
+        "expirationDate": "0922",
+        "firstFour": "4000",
+        "firstName": "Jim",
+        "fsv": "737",
+        "inputMode": 1,
+        "lastFour": "2224",
+        "lastName": "Smith",
+        "lastUsed": "1999-01-01 00:00",
+        "middleName": "",
+        "onlinePaymentCryptogram": "",
+        "p2peInput": "",
+        "paywayToken": 10163736,
+        "phone": "5555555555",
+        "state": "ON",
+        "status": 0,
+        "zip": "K1C2N6"
+    },
+    "cardTransaction": {
+        "addressVerificationResults": "",
+        "amount": 107,
+        "authorizationCode": "0987654321",
+        "authorizedTime": "2021-02-09 13:09:23",
+        "capturedTime": "2021-02-09 13:09:23",
+        "cbMode": 2,
+        "eciType": 1,
+        "fraudSecurityResults": "",
+        "fsvIndicator": "",
+        "name": "6720210209130923241131",
+        "pfpstatus": 3601,
+        "pfpstatusString": "PFP Not Enabled",
+        "processorErrorMessage": "",
+        "processorOrderId": "",
+        "processorRecurringAdvice": "",
+        "processorResponseDate": "",
+        "processorResultCode": "",
+        "processorSequenceNumber": 0,
+        "processorSoftDescriptor": "",
+        "referenceNumber": "123456",
+        "resultCode": 0,
+        "sessionToken_string": "0",
+        "settledTime": "1999-01-01 00:00",
+        "sourceId": 67,
+        "status": 4,
+        "tax": 0,
+        "testResultAVS": "",
+        "testResultFSV": "",
+        "transactionNotes1": "",
+        "transactionNotes2": "",
+        "transactionNotes3": ""
+    },
+    "paywayCode": "5000",
+    "paywayMessage": ""
+  }'
+  end
+
+  def successful_auth_for_void_response
+    '{
+    "cardAccount": {
+        "accountNotes1": "",
+        "accountNotes2": "",
+        "accountNotes3": "",
+        "accountNumber": "400010******2224",
+        "account_number_masked": "400010******2224",
+        "address": "456 My Street Apt 1",
+        "auLastUpdate": "1999-01-01 00:00",
+        "auUpdateType": 0,
+        "cardType": 1,
+        "city": "Ottawa",
+        "commercialCardType": 0,
+        "divisionId": 7,
+        "email": "",
+        "expirationDate": "0922",
+        "firstFour": "4000",
+        "firstName": "Jim",
+        "fsv": "737",
+        "inputMode": 1,
+        "lastFour": "2224",
+        "lastName": "Smith",
+        "lastUsed": "1999-01-01 00:00",
+        "middleName": "",
+        "onlinePaymentCryptogram": "",
+        "p2peInput": "",
+        "paywayToken": 10163736,
+        "phone": "5555555555",
+        "state": "ON",
+        "status": 0,
+        "zip": "K1C2N6"
+    },
+    "cardTransaction": {
+        "addressVerificationResults": "",
+        "amount": 108,
+        "authorizationCode": "0987654321",
+        "authorizedTime": "2021-02-09",
+        "capturedTime": "1999-01-01 00:00:00-05",
+        "cbMode": 2,
+        "eciType": 1,
+        "fraudSecurityResults": "",
+        "fsvIndicator": "",
+        "name": "6720210209135306469560",
+        "pfpstatus": 3601,
+        "pfpstatusString": "PFP Not Enabled",
+        "processorErrorMessage": "",
+        "processorOrderId": "",
+        "processorRecurringAdvice": "",
+        "processorResponseDate": "",
+        "processorResultCode": "",
+        "processorSequenceNumber": 0,
+        "processorSoftDescriptor": "",
+        "referenceNumber": "123456",
+        "resultCode": 0,
+        "sessionToken_string": "0",
+        "settledTime": "1999-01-01 00:00",
+        "sourceId": 67,
+        "status": 3,
+        "tax": 0,
+        "testResultAVS": "",
+        "testResultFSV": "",
+        "transactionNotes1": "",
+        "transactionNotes2": "",
+        "transactionNotes3": ""
+    },
+    "paywayCode": "5000",
+    "paywayMessage": ""
+  }'
+  end
+
+  def successful_void_auth_response
+    '{
+    "cardAccount": {
+        "accountNotes1": "",
+        "accountNotes2": "",
+        "accountNotes3": "",
+        "accountNumber": "400010******2224",
+        "account_number_masked": "400010******2224",
+        "address": "456 My Street Apt 1",
+        "auLastUpdate": "1999-01-01 00:00:00-05",
+        "auUpdateType": 0,
+        "cardType": 1,
+        "city": "Ottawa",
+        "commercialCardType": 0,
+        "divisionId": 7,
+        "email": "",
+        "expirationDate": "0922",
+        "firstFour": "4000",
+        "firstName": "Jim",
+        "fsv": "",
+        "inputMode": 1,
+        "lastFour": "2224",
+        "lastName": "Smith",
+        "lastUsed": "1999-01-01 00:00:00-05",
+        "middleName": "",
+        "onlinePaymentCryptogram": "",
+        "p2peInput": "",
+        "paywayToken": 10163736,
+        "phone": "5555555555",
+        "state": "ON",
+        "status": 2,
+        "zip": "K1C2N6"
+    },
+    "cardTransaction": {
+        "addressVerificationResults": "",
+        "amount": 108,
+        "authorizationCode": "0987654321",
+        "authorizedTime": "2021-02-09 00:00:00-05",
+        "capturedTime": "1999-01-01 00:00:00-05",
+        "cbMode": 2,
+        "eciType": 1,
+        "fraudSecurityResults": "",
+        "fsvIndicator": "",
+        "name": "6720210209135306469560",
+        "pfpstatus": 3601,
+        "pfpstatusString": "PFP Not Enabled",
+        "processorErrorMessage": "",
+        "processorOrderId": "",
+        "processorRecurringAdvice": "",
+        "processorResponseDate": "",
+        "processorResultCode": "",
+        "processorSequenceNumber": 0,
+        "processorSoftDescriptor": "",
+        "referenceNumber": "123456",
+        "resultCode": 0,
+        "sessionToken_string": "0",
+        "settledTime": "1999-01-01 00:00",
+        "sourceId": 67,
+        "status": 6,
+        "tax": 0,
+        "testResultAVS": "",
+        "testResultFSV": "",
+        "transactionNotes1": "",
+        "transactionNotes2": "",
+        "transactionNotes3": ""
+    },
+    "paywayCode": "5000",
+    "paywayMessage": ""
+  }'
+  end
+
+  def successful_void_response
+    '{
+    "cardAccount": {
+        "accountNotes1": "",
+        "accountNotes2": "",
+        "accountNotes3": "",
+        "accountNumber": "",
+        "account_number_masked": "",
+        "address": "",
+        "auLastUpdate": "1999-01-01 00:00",
+        "auUpdateType": 0,
+        "cardType": 8,
+        "city": "",
+        "commercialCardType": 0,
+        "divisionId": 0,
+        "email": "",
+        "expirationDate": "",
+        "firstFour": "",
+        "firstName": "",
+        "fsv": "",
+        "inputMode": 1,
+        "lastFour": "",
+        "lastName": "",
+        "lastUsed": "1999-01-01 00:00",
+        "middleName": "",
+        "onlinePaymentCryptogram": "",
+        "p2peInput": "",
+        "paywayToken": 0,
+        "phone": "",
+        "state": "",
+        "status": 0,
+        "zip": ""
+    },
+    "cardTransaction": {
+        "addressVerificationResults": "",
+        "amount": 0,
+        "authorizationCode": "",
+        "authorizedTime": "1999-01-01",
+        "capturedTime": "1999-01-01",
+        "cbMode": 0,
+        "eciType": 0,
+        "fraudSecurityResults": "",
+        "fsvIndicator": "",
+        "name": "",
+        "pfpstatus": 3601,
+        "pfpstatusString": "PFP Not Enabled",
+        "processorErrorMessage": "",
+        "processorOrderId": "",
+        "processorRecurringAdvice": "",
+        "processorResponseDate": "",
+        "processorResultCode": "",
+        "processorSequenceNumber": 0,
+        "processorSoftDescriptor": "",
+        "referenceNumber": "",
+        "resultCode": 1,
+        "sessionToken_string": "0",
+        "settledTime": "1999-01-01 00:00",
+        "sourceId": 0,
+        "status": 0,
+        "tax": 0,
+        "testResultAVS": "",
+        "testResultFSV": "",
+        "transactionNotes1": "",
+        "transactionNotes2": "",
+        "transactionNotes3": ""
+    },
+    "paywayCode": "5025",
+    "paywayMessage": "failed to read transaction with source 0 and name "
+  }'
+  end
+
+  def failed_void_response
+    '{
+    "cardAccount": {
+        "accountNotes1": "",
+        "accountNotes2": "",
+        "accountNotes3": "",
+        "accountNumber": "",
+        "account_number_masked": "",
+        "address": "",
+        "auLastUpdate": "1999-01-01 00:00",
+        "auUpdateType": 0,
+        "cardType": 8,
+        "city": "",
+        "commercialCardType": 0,
+        "divisionId": 0,
+        "email": "",
+        "expirationDate": "",
+        "firstFour": "",
+        "firstName": "",
+        "fsv": "",
+        "inputMode": 1,
+        "lastFour": "",
+        "lastName": "",
+        "lastUsed": "1999-01-01 00:00",
+        "middleName": "",
+        "onlinePaymentCryptogram": "",
+        "p2peInput": "",
+        "paywayToken": 0,
+        "phone": "",
+        "state": "",
+        "status": 0,
+        "zip": ""
+    },
+    "cardTransaction": {
+        "addressVerificationResults": "",
+        "amount": 0,
+        "authorizationCode": "",
+        "authorizedTime": "1999-01-01",
+        "capturedTime": "1999-01-01",
+        "cbMode": 0,
+        "eciType": 0,
+        "fraudSecurityResults": "",
+        "fsvIndicator": "",
+        "name": "",
+        "pfpstatus": 3601,
+        "pfpstatusString": "PFP Not Enabled",
+        "processorErrorMessage": "",
+        "processorOrderId": "",
+        "processorRecurringAdvice": "",
+        "processorResponseDate": "",
+        "processorResultCode": "",
+        "processorSequenceNumber": 0,
+        "processorSoftDescriptor": "",
+        "referenceNumber": "",
+        "resultCode": 1,
+        "sessionToken_string": "0",
+        "settledTime": "1999-01-01 00:00",
+        "sourceId": 0,
+        "status": 0,
+        "tax": 0,
+        "testResultAVS": "",
+        "testResultFSV": "",
+        "transactionNotes1": "",
+        "transactionNotes2": "",
+        "transactionNotes3": ""
+    },
+    "paywayCode": "5025",
+    "paywayMessage": "failed to read transaction with source 0 and name "
+  }'
+  end
+  
+  def successful_sale_for_void_response
+    '{
+    "cardAccount": {
+        "accountNotes1": "",
+        "accountNotes2": "",
+        "accountNotes3": "",
+        "accountNumber": "400010******2224",
+        "account_number_masked": "400010******2224",
+        "address": "456 My Street Apt 1",
+        "auLastUpdate": "1999-01-01 00:00:00-05",
+        "auUpdateType": 0,
+        "cardType": 1,
+        "city": "Ottawa",
+        "commercialCardType": 0,
+        "divisionId": 7,
+        "email": "",
+        "expirationDate": "0922",
+        "firstFour": "4000",
+        "firstName": "Jim",
+        "fsv": "",
+        "inputMode": 1,
+        "lastFour": "2224",
+        "lastName": "Smith",
+        "lastUsed": "1999-01-01 00:00:00-05",
+        "middleName": "",
+        "onlinePaymentCryptogram": "",
+        "p2peInput": "",
+        "paywayToken": 10163736,
+        "phone": "5555555555",
+        "state": "ON",
+        "status": 2,
+        "zip": "K1C2N6"
+    },
+    "cardTransaction": {
+        "addressVerificationResults": "",
+        "amount": 109,
+        "authorizationCode": "0987654321",
+        "authorizedTime": "2021-02-09 00:00:00-05",
+        "capturedTime": "2021-02-09 13:00:48",
+        "cbMode": 2,
+        "eciType": 1,
+        "fraudSecurityResults": "",
+        "fsvIndicator": "",
+        "name": "6720210209130047957988",
+        "pfpstatus": 3601,
+        "pfpstatusString": "PFP Not Enabled",
+        "processorErrorMessage": "",
+        "processorOrderId": "",
+        "processorRecurringAdvice": "",
+        "processorResponseDate": "",
+        "processorResultCode": "",
+        "processorSequenceNumber": 0,
+        "processorSoftDescriptor": "",
+        "referenceNumber": "123456",
+        "resultCode": 0,
+        "sessionToken_string": "0",
+        "settledTime": "1999-01-01 00:00",
+        "sourceId": 67,
+        "status": 4,
+        "tax": 0,
+        "testResultAVS": "",
+        "testResultFSV": "",
+        "transactionNotes1": "",
+        "transactionNotes2": "",
+        "transactionNotes3": ""
+    },
+    "paywayCode": "5000",
+    "paywayMessage": ""
+  }'
+  end
+    
+  def successful_void_sale_response
+    '{
+    "cardAccount": {
+        "accountNotes1": "",
+        "accountNotes2": "",
+        "accountNotes3": "",
+        "accountNumber": "400010******2224",
+        "account_number_masked": "400010******2224",
+        "address": "456 My Street Apt 1",
+        "auLastUpdate": "1999-01-01 00:00:00-05",
+        "auUpdateType": 0,
+        "cardType": 1,
+        "city": "Ottawa",
+        "commercialCardType": 0,
+        "divisionId": 7,
+        "email": "",
+        "expirationDate": "0922",
+        "firstFour": "4000",
+        "firstName": "Jim",
+        "fsv": "",
+        "inputMode": 1,
+        "lastFour": "2224",
+        "lastName": "Smith",
+        "lastUsed": "1999-01-01 00:00:00-05",
+        "middleName": "",
+        "onlinePaymentCryptogram": "",
+        "p2peInput": "",
+        "paywayToken": 10163736,
+        "phone": "5555555555",
+        "state": "ON",
+        "status": 2,
+        "zip": "K1C2N6"
+    },
+    "cardTransaction": {
+        "addressVerificationResults": "",
+        "amount": 109,
+        "authorizationCode": "0987654321",
+        "authorizedTime": "2021-02-09 00:00:00-05",
+        "capturedTime": "2021-02-09 13:00:48-05",
+        "cbMode": 2,
+        "eciType": 1,
+        "fraudSecurityResults": "",
+        "fsvIndicator": "",
+        "name": "6720210209130047957988",
+        "pfpstatus": 3601,
+        "pfpstatusString": "PFP Not Enabled",
+        "processorErrorMessage": "",
+        "processorOrderId": "",
+        "processorRecurringAdvice": "",
+        "processorResponseDate": "",
+        "processorResultCode": "",
+        "processorSequenceNumber": 0,
+        "processorSoftDescriptor": "",
+        "referenceNumber": "123456",
+        "resultCode": 0,
+        "sessionToken_string": "0",
+        "settledTime": "1999-01-01 00:00",
+        "sourceId": 67,
+        "status": 6,
+        "tax": 0,
+        "testResultAVS": "",
+        "testResultFSV": "",
+        "transactionNotes1": "",
+        "transactionNotes2": "",
+        "transactionNotes3": ""
+    },
+    "paywayCode": "5000",
+    "paywayMessage": ""
+  }'
+  end
+    
+  def successful_credit_for_void_response
+    '{
+    "cardAccount": {
+        "accountNotes1": "",
+        "accountNotes2": "",
+        "accountNotes3": "",
+        "accountNumber": "400010******2224",
+        "account_number_masked": "400010******2224",
+        "address": "456 My Street Apt 1",
+        "auLastUpdate": "1999-01-01 00:00",
+        "auUpdateType": 0,
+        "cardType": 1,
+        "city": "Ottawa",
+        "commercialCardType": 0,
+        "divisionId": 7,
+        "email": "",
+        "expirationDate": "0922",
+        "firstFour": "4000",
+        "firstName": "Jim",
+        "fsv": "737",
+        "inputMode": 1,
+        "lastFour": "2224",
+        "lastName": "Smith",
+        "lastUsed": "1999-01-01 00:00",
+        "middleName": "",
+        "onlinePaymentCryptogram": "",
+        "p2peInput": "",
+        "paywayToken": 10163736,
+        "phone": "5555555555",
+        "state": "ON",
+        "status": 0,
+        "zip": "K1C2N6"
+    },
+    "cardTransaction": {
+        "addressVerificationResults": "",
+        "amount": 110,
+        "authorizationCode": "0987654321",
+        "authorizedTime": "2021-02-09 13:06:33",
+        "capturedTime": "2021-02-09 13:06:33",
+        "cbMode": 2,
+        "eciType": 1,
+        "fraudSecurityResults": "",
+        "fsvIndicator": "",
+        "name": "6720210209130633236167",
+        "pfpstatus": 3601,
+        "pfpstatusString": "PFP Not Enabled",
+        "processorErrorMessage": "",
+        "processorOrderId": "",
+        "processorRecurringAdvice": "",
+        "processorResponseDate": "",
+        "processorResultCode": "",
+        "processorSequenceNumber": 0,
+        "processorSoftDescriptor": "",
+        "referenceNumber": "123456",
+        "resultCode": 0,
+        "sessionToken_string": "0",
+        "settledTime": "1999-01-01 00:00",
+        "sourceId": 67,
+        "status": 4,
+        "tax": 0,
+        "testResultAVS": "",
+        "testResultFSV": "",
+        "transactionNotes1": "",
+        "transactionNotes2": "",
+        "transactionNotes3": ""
+    },
+    "paywayCode": "5000",
+    "paywayMessage": ""
+  }'
+  end
+    
+  def successful_credit_void_response
+    '{
+    "cardAccount": {
+        "accountNotes1": "",
+        "accountNotes2": "",
+        "accountNotes3": "",
+        "accountNumber": "400010******2224",
+        "account_number_masked": "400010******2224",
+        "address": "456 My Street Apt 1",
+        "auLastUpdate": "1999-01-01 00:00:00-05",
+        "auUpdateType": 0,
+        "cardType": 1,
+        "city": "Ottawa",
+        "commercialCardType": 0,
+        "divisionId": 7,
+        "email": "",
+        "expirationDate": "0922",
+        "firstFour": "4000",
+        "firstName": "Jim",
+        "fsv": "",
+        "inputMode": 1,
+        "lastFour": "2224",
+        "lastName": "Smith",
+        "lastUsed": "1999-01-01 00:00:00-05",
+        "middleName": "",
+        "onlinePaymentCryptogram": "",
+        "p2peInput": "",
+        "paywayToken": 10163736,
+        "phone": "5555555555",
+        "state": "ON",
+        "status": 2,
+        "zip": "K1C2N6"
+    },
+    "cardTransaction": {
+        "addressVerificationResults": "",
+        "amount": 110,
+        "authorizationCode": "0987654321",
+        "authorizedTime": "2021-02-09 14:02:51-05",
+        "capturedTime": "2021-02-09 14:02:51-05",
+        "cbMode": 2,
+        "eciType": 1,
+        "fraudSecurityResults": "",
+        "fsvIndicator": "",
+        "name": "672021020914025188146",
+        "pfpstatus": 3601,
+        "pfpstatusString": "PFP Not Enabled",
+        "processorErrorMessage": "",
+        "processorOrderId": "",
+        "processorRecurringAdvice": "",
+        "processorResponseDate": "",
+        "processorResultCode": "",
+        "processorSequenceNumber": 0,
+        "processorSoftDescriptor": "",
+        "referenceNumber": "123456",
+        "resultCode": 0,
+        "sessionToken_string": "0",
+        "settledTime": "1999-01-01 00:00",
+        "sourceId": 67,
+        "status": 6,
+        "tax": 0,
+        "testResultAVS": "",
+        "testResultFSV": "",
+        "transactionNotes1": "",
+        "transactionNotes2": "",
+        "transactionNotes3": ""
+    },
+    "paywayCode": "5000",
+    "paywayMessage": ""
+  }'
+  end
+  
+  def failed_invalid_login_response
+    '{
+    "paywayCode": "5001",
+    "paywayMessage": "Session timed out or other session error.  Create new session"
+    }'
+  end
+end
+

--- a/test/unit/gateways/payway_dot_com_test.rb
+++ b/test/unit/gateways/payway_dot_com_test.rb
@@ -65,7 +65,7 @@ class PaywayDotComTest < Test::Unit::TestCase
   def test_failed_authorize
     @gateway.expects(:ssl_request).returns(failed_authorize_response)
 
-    response = @gateway.authorize(105, @invalid_luhn_card, @options)
+    response = @gateway.authorize(105, @credit_card, @options)
     assert_failure response
     assert_equal '5035', response.message[0,4]
   end

--- a/test/unit/gateways/payway_dot_com_test.rb
+++ b/test/unit/gateways/payway_dot_com_test.rb
@@ -6,7 +6,6 @@ class PaywayDotComTest < Test::Unit::TestCase
         login: 'sprerestwsdev',
         password: 'sprerestwsdev1!',
         company_id: '3')
-    @gateway2 = PaywayDotComGateway.new(login: '', password: '', company_id: '')
     @credit_card = credit_card
     @amount = 100
 
@@ -86,11 +85,19 @@ class PaywayDotComTest < Test::Unit::TestCase
     assert_equal '5000', credit.message[0,4]
   end
 
+  def test_failed_credit
+    @gateway.expects(:ssl_request).returns(failed_credit_response)
+  
+    response = @gateway.credit(108, @credit_card, @options)
+    assert_failure response
+    assert_equal '5035', response.message[0,4]
+  end
+
   # void authorization only
   def test_successful_void
     @gateway.expects(:ssl_request).returns(successful_auth_for_void_response)
   
-    auth = @gateway.authorize(108, @credit_card, @options)
+    auth = @gateway.authorize(109, @credit_card, @options)
     assert_success auth
 
     @gateway.expects(:ssl_request).returns(successful_void_auth_response)
@@ -113,7 +120,7 @@ class PaywayDotComTest < Test::Unit::TestCase
   def test_successful_void_of_sale
     @gateway.expects(:ssl_request).returns(successful_sale_for_void_response)
   
-    sale = @gateway.purchase(109, @credit_card, @options)
+    sale = @gateway.purchase(110, @credit_card, @options)
     assert_success sale
 
     @gateway.expects(:ssl_request).returns(successful_void_sale_response)
@@ -128,7 +135,7 @@ class PaywayDotComTest < Test::Unit::TestCase
   def test_successful_void_of_credit
     @gateway.expects(:ssl_request).returns(successful_credit_for_void_response)
   
-    credit = @gateway.credit(110, @credit_card, @options)
+    credit = @gateway.credit(111, @credit_card, @options)
     assert_success credit
 
     @gateway.expects(:ssl_request).returns(successful_credit_void_response)
@@ -140,6 +147,7 @@ class PaywayDotComTest < Test::Unit::TestCase
   end
 
   def test_invalid_login
+    @gateway2 = PaywayDotComGateway.new(login: '', password: '', company_id: '')
     @gateway2.expects(:ssl_request).returns(failed_invalid_login_response)
 
     assert response = @gateway2.purchase(@amount, @credit_card, @options)
@@ -153,8 +161,6 @@ class PaywayDotComTest < Test::Unit::TestCase
   end
 
   private
-
-#<- "POST /PaywayWS/Payment/CreditCard HTTP/1.1\r\nContent-Type: application/json\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: devedgilpayway.net\r\nContent-Length: 436\r\n\r\n"
 
   def pre_scrubbed
     %q(
@@ -171,8 +177,6 @@ SSL established, protocol: TLSv1.2, cipher: AES256-GCM-SHA384
 -> "Content-Length: 2051\r\n"
 )
   end
-
-#<- "POST /PaywayWS/Payment/CreditCard HTTP/1.1\r\nContent-Type: application/json\r\nAccept: application/json\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nHost: devedgilpayway.net\r\nContent-Length: 436\r\n\r\n"
 
   def post_scrubbed
     %q(
@@ -261,16 +265,6 @@ SSL established, protocol: TLSv1.2, cipher: AES256-GCM-SHA384
   }'
   end
   
-    %(
-      Easy to capture by setting the DEBUG_ACTIVE_MERCHANT environment variable
-      to "true" when running remote tests:
-
-      $ DEBUG_ACTIVE_MERCHANT=true ruby -Itest \
-        test/remote/gateways/remote_payway_dot_com_test.rb \
-        -n test_successful_purchase
-    )
-
-
   def failed_purchase_response
   '{
     "cardAccount": {
@@ -765,6 +759,77 @@ SSL established, protocol: TLSv1.2, cipher: AES256-GCM-SHA384
     },
     "paywayCode": "5000",
     "paywayMessage": ""
+  }'
+  end
+
+  def failed_credit_response
+  '{
+    "cardAccount": {
+        "accountNotes1": "",
+        "accountNotes2": "",
+        "accountNotes3": "",
+        "accountNumber": "400030******2221",
+        "account_number_masked": "400030******2221",
+        "address": "456 My Street Apt 1",
+        "auLastUpdate": "1999-01-01 00:00",
+        "auUpdateType": 0,
+        "cardType": 1,
+        "city": "Ottawa",
+        "commercialCardType": 0,
+        "divisionId": 7,
+        "email": "",
+        "expirationDate": "0922",
+        "firstFour": "4000",
+        "firstName": "Jim",
+        "fsv": "123",
+        "inputMode": 1,
+        "lastFour": "2221",
+        "lastName": "Smith",
+        "lastUsed": "1999-01-01 00:00",
+        "middleName": "",
+        "onlinePaymentCryptogram": "",
+        "p2peInput": "",
+        "paywayToken": 0,
+        "phone": "5555555555",
+        "state": "ON",
+        "status": 2,
+        "zip": "K1C2N6"
+    },
+    "cardTransaction": {
+        "addressVerificationResults": "",
+        "amount": 0,
+        "authorizationCode": "",
+        "authorizedTime": "1999-01-01",
+        "capturedTime": "1999-01-01",
+        "cbMode": 0,
+        "eciType": 0,
+        "fraudSecurityResults": "",
+        "fsvIndicator": "",
+        "name": "",
+        "pfpstatus": 3601,
+        "pfpstatusString": "PFP Not Enabled",
+        "processorErrorMessage": "",
+        "processorOrderId": "",
+        "processorRecurringAdvice": "",
+        "processorResponseDate": "",
+        "processorResultCode": "",
+        "processorSequenceNumber": 0,
+        "processorSoftDescriptor": "",
+        "referenceNumber": "",
+        "resultCode": 1,
+        "sessionToken_string": "0",
+        "settledTime": "1999-01-01 00:00",
+        "sourceId": 0,
+        "status": 0,
+        "tax": 0,
+        "testResultAVS": "",
+        "testResultFSV": "",
+        "transactionNotes1": "",
+        "transactionNotes2": "",
+        "transactionNotes3": ""
+    },
+    "paywayCode": "5035",
+    "paywayMessage": "Invalid account number: 4000300011112221"
   }'
   end
 


### PR DESCRIPTION
Commits on Jan 12, 2022
updated Production and test endpoint URLs (old ones are deprecated as of Jan 31st 2022 and just return PaywayCode only for gateway_specific_response_field message field

Updated file, payway_dot_com.rb in active_merchant/lib/active_merchant/billing/gateways/

The main fix was to change the production and test endpoint URLs to Payway. 

The new ones are pawywayws.com for production and paywaywsdev.com for test:

      self.test_url = 'https://paywaywsdev.com/PaywayWS/Payment/CreditCard'
      self.live_url = 'https://paywayws.com/PaywayWS/Payment/CreditCard'

The production one is deprecated as of Jan. 31st. 

Dan